### PR TITLE
Clean up untested methods

### DIFF
--- a/lib/ethereum/base.rb
+++ b/lib/ethereum/base.rb
@@ -5,6 +5,7 @@ module Ethereum
   module Base
 
     BYTE_ZERO = "\x00".freeze
+    UINT256_MAX = 2**256 - 1
 
     autoload :Gas, 'ethereum/base/gas'
     autoload :Secp256K1, 'ethereum/base/secp256k1'

--- a/lib/ethereum/base/utils.rb
+++ b/lib/ethereum/base/utils.rb
@@ -141,5 +141,10 @@ module Ethereum::Base
       end
     end
 
+    def lpad(x, symbol, l)
+      return x if x.size >= l
+      symbol * (l - x.size) + x
+    end
+
   end
 end

--- a/lib/ethereum/base/utils.rb
+++ b/lib/ethereum/base/utils.rb
@@ -25,14 +25,6 @@ module Ethereum::Base
       RLP::Utils.decode_hex s
     end
 
-    def encode_rlp(b)
-      RLP.encode b
-    end
-
-    def decode_rlp(s)
-      RLP.decode s
-    end
-
     def big_endian_to_int(s)
       RLP::Sedes.big_endian_int.deserialize s.sub(/\A(\x00)+/, '')
     end
@@ -43,16 +35,6 @@ module Ethereum::Base
 
     def remove_0x_head(s)
       s[0,2] == '0x' ? s[2..-1] : s
-    end
-
-    def parse_int_or_hex(s)
-      if s.is_a?(Numeric)
-        s
-      elsif s[0,2] == '0x'
-        big_endian_to_int decode_hex(normalize_hex_without_prefix(s))
-      else
-        s.to_i
-      end
     end
 
     def normalize_hex_without_prefix(s)
@@ -73,10 +55,6 @@ module Ethereum::Base
 
     def hash160_hex(x)
       encode_hex hash160(x)
-    end
-
-    def to_signed(i)
-      i > Constant::INT_MAX ? (i-Constant::TT256) : i
     end
 
     def ceil32(x)

--- a/lib/ethereum/base/utils.rb
+++ b/lib/ethereum/base/utils.rb
@@ -104,12 +104,18 @@ module Ethereum::Base
     end
 
     def encode_int(n)
-      raise ArgumentError, "Integer invalid or out of range: #{n}" unless n.is_a?(Integer) && n >= 0 && n <= UINT_MAX
+      unless n.is_a?(Integer) && n >= 0 && n <= UINT256_MAX
+        raise ArgumentError, "Integer invalid or out of range: #{n}"
+      end
+
       int_to_big_endian n
     end
 
     def decode_int(v)
-      raise ArgumentError, "No leading zero bytes allowed for integers" if v.size > 0 && (v[0] == Constant::BYTE_ZERO || v[0] == 0)
+      if v.size > 0 && (v[0] == BYTE_ZERO || v[0] == 0)
+        raise ArgumentError, "No leading zero bytes allowed for integers"
+      end
+
       big_endian_to_int v
     end
 

--- a/lib/ethereum/base/version.rb
+++ b/lib/ethereum/base/version.rb
@@ -1,7 +1,7 @@
 module Ethereum
   module Base
 
-    VERSION = "0.1.4"
+    VERSION = "0.1.5"
 
   end
 end

--- a/test/base/utils_test.rb
+++ b/test/base/utils_test.rb
@@ -46,4 +46,12 @@ class UtilsTest < Minitest::Test
     assert_equal 571329460454981322332848927582483177110542410654, coerce_to_int("d\x13L\x8F\x0E\xD5*\x13\xBD\n\x00\xFF\x9F\xC6\xDBn\b2\xE3\x9E")
   end
 
+  def test_coerce_to_bytes
+    assert_equal "d\x13L\x8F\x0E\xD5*\x13\xBD\n\x00\xFF\x9F\xC6\xDBn\b2\xE3\x9E", coerce_to_bytes(571329460454981322332848927582483177110542410654)
+  end
+
+  def test_coerce_addr_to_hex
+    assert_equal "64134c8f0ed52a13bd0a00ff9fc6db6e0832e39e", coerce_addr_to_hex(571329460454981322332848927582483177110542410654)
+  end
+
 end


### PR DESCRIPTION
This pull request cleans up some of the methods that were not tested, and so seemingly unused. Fixes various problems like referring to classes and constants that didn't exist, which I missed at the first pass of originally pulling this out of ruby-ethereum. Additionally adds some tests, and a related missing function for some useful methods.

This is really just supposed to clean up the gem, as it was pulled out rather quickly initially.